### PR TITLE
Removes sports teams from December 2017 attendance

### DIFF
--- a/src/shared/december2017data.js
+++ b/src/shared/december2017data.js
@@ -17,31 +17,6 @@ const december2017data = [
     about: 'yah',
   },
   {
-    name: 'Dallas Mavericks',
-    twitter: 'dallasmavs',
-    about: 'DIIIIIIIIIIIIIIIIIIIIIIIIIIIIRK!',
-  },
-  {
-    name: 'Dallas Stars',
-    twitter: 'DallasStars',
-    about: 'Hat tricks a plenty',
-  },
-  {
-    name: 'Dallas Cowboys',
-    twitter: 'dallascowboys',
-    about: 'America\'s team for American-style football',
-  },
-  {
-    name: 'Texas Rangers',
-    twitter: 'Rangers',
-    about: 'Bases-ball',
-  },
-  {
-    name: 'FC Dallas',
-    twitter: 'FCDallas',
-    about: 'Real football',
-  },
-  {
     name: 'Chris Kee',
     twitter: 'chriskeephoto',
     about: 'Guitar!',


### PR DESCRIPTION
These keys were added to the data file as filler for our UI to look better at first. Now that people have added themselves, the sports teams can vanish!