### PR TITLE
Adds em dash(—) for table cells without a twitter handle

### DIFF
--- a/src/attendance/dialog-attendance.js
+++ b/src/attendance/dialog-attendance.js
@@ -68,7 +68,7 @@ const AttendanceDialog = (props) => {
             return (
               <TableRow key={dev.name}>
                 <TableCell>{dev.name}</TableCell>
-                <TableCell>@{dev.twitter}</TableCell>
+                <TableCell>{dev.twitter ? `@${dev.twitter}` : '—'}</TableCell>
                 <TableCell>{dev.about}</TableCell>
               </TableRow>
             );


### PR DESCRIPTION
Some of our devs choose not to use Twitter—or at least provided no Twitter handle for their data. 

Instead of showing:

```javascript
@
```

...we are now showing:

```javascript
—
```
