### PR TITLE
[npm] Upgrade Material-UI to version beta 25

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "babel-core": "^6.26.0",
     "babel-jest": "^22.0.3",
-    "material-ui": "^1.0.0-beta.23",
+    "material-ui": "^1.0.0-beta.24",
     "material-ui-icons": "^1.0.0-beta.17",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "babel-core": "^6.26.0",
     "babel-jest": "^22.0.3",
-    "material-ui": "^1.0.0-beta.24",
+    "material-ui": "^1.0.0-beta.25",
     "material-ui-icons": "^1.0.0-beta.17",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",

--- a/src/attendance/dialog-attendance.js
+++ b/src/attendance/dialog-attendance.js
@@ -34,7 +34,7 @@ const AttendanceDialog = (props) => {
   const {
     classes,
     isOpen,
-    onRequestCloseDialog,
+    onCloseDialog,
   } = props;
 
 
@@ -42,12 +42,12 @@ const AttendanceDialog = (props) => {
     <Dialog
       fullScreen
       open={isOpen}
-      onRequestClose={onRequestCloseDialog}
+      onClose={onCloseDialog}
       transition={Transition}
     >
       <AppBar className={classes.appBar}>
         <Toolbar>
-          <IconButton color="contrast" onClick={onRequestCloseDialog} aria-label="Close">
+          <IconButton color="contrast" onClick={onCloseDialog} aria-label="Close">
             <CloseIcon />
           </IconButton>
           <Typography type="title" color="inherit" className={classes.flex}>

--- a/src/attendance/index.js
+++ b/src/attendance/index.js
@@ -54,7 +54,7 @@ class Attendance extends Component {
     });
   }
 
-  handleRequestCloseDialog = () => {
+  handleCloseDialog = () => {
     this.setState({
       isOpen: false,
     });
@@ -93,7 +93,7 @@ class Attendance extends Component {
         </div>
         <AttendanceDialog
           isOpen={isOpen}
-          onRequestCloseDialog={this.handleRequestCloseDialog}
+          onCloseDialog={this.handleCloseDialog}
         />
       </section>
     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -4283,9 +4283,9 @@ material-ui-icons@^1.0.0-beta.17:
   dependencies:
     recompose "^0.26.0"
 
-material-ui@^1.0.0-beta.23:
-  version "1.0.0-beta.23"
-  resolved "https://registry.yarnpkg.com/material-ui/-/material-ui-1.0.0-beta.23.tgz#f3d49359c13b57f893e768de62b81f5e8ad7faa5"
+material-ui@^1.0.0-beta.24:
+  version "1.0.0-beta.25"
+  resolved "https://registry.yarnpkg.com/material-ui/-/material-ui-1.0.0-beta.25.tgz#9d5bf97cebc553a5bca28e490823943d9ffb0ebc"
   dependencies:
     babel-runtime "^6.26.0"
     brcast "^3.0.1"
@@ -4300,7 +4300,6 @@ material-ui@^1.0.0-beta.23:
     normalize-scroll-left "^0.1.2"
     prop-types "^15.6.0"
     react-event-listener "^0.5.1"
-    react-flow-types "^0.2.0-beta.6"
     react-jss "^8.1.0"
     react-popper "^0.7.4"
     react-scrollbar-size "^2.0.2"
@@ -5537,10 +5536,6 @@ react-event-listener@^0.5.0, react-event-listener@^0.5.1:
     fbjs "^0.8.16"
     prop-types "^15.6.0"
     warning "^3.0.0"
-
-react-flow-types@^0.2.0-beta.6:
-  version "0.2.0-beta.6"
-  resolved "https://registry.yarnpkg.com/react-flow-types/-/react-flow-types-0.2.0-beta.6.tgz#bf49c8b7864fcd0951b03286c63a80d66ce9fae4"
 
 react-jss@^8.1.0:
   version "8.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4283,7 +4283,7 @@ material-ui-icons@^1.0.0-beta.17:
   dependencies:
     recompose "^0.26.0"
 
-material-ui@^1.0.0-beta.24:
+material-ui@^1.0.0-beta.25:
   version "1.0.0-beta.25"
   resolved "https://registry.yarnpkg.com/material-ui/-/material-ui-1.0.0-beta.25.tgz#9d5bf97cebc553a5bca28e490823943d9ffb0ebc"
   dependencies:


### PR DESCRIPTION
This upgrades Material-UI incrementally to both:
- [version beta 24](https://github.com/mui-org/material-ui/releases/tag/v1.0.0-beta.24)
- [version beta 25](https://github.com/mui-org/material-ui/releases/tag/v1.0.0-beta.25)

Staying current!

# 😆 